### PR TITLE
Add local directory reference to psexec

### DIFF
--- a/BulkInstall-CarbonBlackSensor.ps1
+++ b/BulkInstall-CarbonBlackSensor.ps1
@@ -151,7 +151,7 @@ foreach ($Client in $ComputerList) {
 
                              # Running the installer if the CB installer folder is already located on the C:\Temp
                              #  maybe unnecessary here, but useful for any reason the install fails the first time
-                           & psexec.exe -accepteula "\\$Client" "C:\temp\CarbonBlackClientSetup.exe" /S
+                           & .\psexec.exe -accepteula "\\$Client" "C:\temp\CarbonBlackClientSetup.exe" /S
                            $PSExecLastExitCode = $LASTEXITCODE
                            Write-Output "Last Exit Code of PSEXEC on Client $Client, $PSExecLastExitCode"
 
@@ -164,7 +164,7 @@ foreach ($Client in $ComputerList) {
                            
                              # run the PSEXEC.EXE executable and then the command to run the CarbonBlack Sensor using
                              #  the silent install switch for CB Sensor
-                           & psexec.exe -accepteula "\\$Client" "C:\Temp\CarbonBlackSensor\CarbonBlackClientSetup.exe" /S
+                           & .\psexec.exe -accepteula "\\$Client" "C:\Temp\CarbonBlackSensor\CarbonBlackClientSetup.exe" /S
                            
                            $PSExecLastExitCode = $LASTEXITCODE
                            


### PR DESCRIPTION
Fixes https://github.com/mfkhan237/remote-install-cbsensor/issues/3

_In this example, CarbonBlackSensor.exe is just a renamed version of PsExec for testing_
```
PS C:\temp> .\BulkInstall-CarbonBlackSensor.ps1

cmdlet BulkInstall-CarbonBlackSensor at command pipeline position 1
Supply values for the following parameters:
(Type !? for Help.)
PathOfComputerList: hostnames.txt
CarbonBlackSensorInstallerPath: CarbonBlackSensor
Pinging localhost
localhost is online, Proceed to next step
'CarbonBlack' service is Not Running on localhost, proceeding to Installation
Copying CarbonBlackSensor folder...
...To localhost's c:\Temp directory

Connecting to localhost...PsExec v2.2 - Execute processes remotely
Copyright (C) 2001-2016 Mark Russinovich
Sysinternals - www.sysinternals.com

Starting C:\Temp\CarbonBlackSensor\CarbonBlackClientSetup.exe on localhost...

PsExec v2.2 - Execute processes remotelyC:\Temp\CarbonBlackSensor\CarbonBlackClientSetup.exe exited on localhost with error code -1.

Copyright (C) 2001-2016 Mark Russinovich
Sysinternals - www.sysinternals.com

PsExec executes a program on a remote system, where remotely executed console
applications execute interactively.
<snip>
```
